### PR TITLE
Add support for SSD1306 and SH1106 I2C displays for STM32F1

### DIFF
--- a/src/clib/u8g.h
+++ b/src/clib/u8g.h
@@ -693,6 +693,8 @@ uint8_t u8g_com_msp430_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
 uint8_t u8g_com_raspberrypi_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);                /* u8g_com_rasperrypi_hw_spi.c */
 uint8_t u8g_com_raspberrypi_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);    /* u8g_com_raspberrypi_ssd_i2c.c */
 
+uint8_t u8g_com_stm32duino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);    /* u8g_com_stm32duino_ssd_i2c.cpp */
+
 
 /*
   Translation of system specific com drives to generic com names
@@ -844,6 +846,12 @@ defined(__18CXX) || defined(__PIC32MX)
 #ifndef U8G_COM_SSD_I2C
 #if defined(U8G_RASPBERRY_PI)
 #define U8G_COM_SSD_I2C u8g_com_raspberrypi_ssd_i2c_fn
+#endif
+#endif
+
+#ifndef U8G_COM_SSD_I2C
+#if defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#define U8G_COM_SSD_I2C u8g_com_stm32duino_ssd_i2c_fn
 #endif
 #endif
 

--- a/src/clib/u8g_com_arduino_common.c
+++ b/src/clib/u8g_com_arduino_common.c
@@ -38,7 +38,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_fast_parallel.c
+++ b/src/clib/u8g_com_arduino_fast_parallel.c
@@ -59,7 +59,7 @@
 
 #include "u8g.h"
 
-#if  defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 //#include <WProgram.h>

--- a/src/clib/u8g_com_arduino_no_en_parallel.c
+++ b/src/clib/u8g_com_arduino_no_en_parallel.c
@@ -59,7 +59,7 @@
 
 #include "u8g.h"
 
-#if  defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 //#include <WProgram.h>

--- a/src/clib/u8g_com_arduino_parallel.c
+++ b/src/clib/u8g_com_arduino_parallel.c
@@ -55,7 +55,7 @@
 #include "u8g.h"
 
 
-#if  defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_port_d_wr.c
+++ b/src/clib/u8g_com_arduino_port_d_wr.c
@@ -54,7 +54,7 @@
 #include "u8g.h"
 
 
-#if  defined(ARDUINO) && defined(PORTD)
+#if defined(ARDUINO) && defined(PORTD) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_st7920_custom.c
+++ b/src/clib/u8g_com_arduino_st7920_custom.c
@@ -47,7 +47,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_st7920_hw_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_hw_spi.c
@@ -37,7 +37,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_st7920_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_spi.c
@@ -44,7 +44,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_std_sw_spi.c
+++ b/src/clib/u8g_com_arduino_std_sw_spi.c
@@ -36,7 +36,7 @@
 #include "u8g.h"
 
 
-#if defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_sw_spi.c
+++ b/src/clib/u8g_com_arduino_sw_spi.c
@@ -42,7 +42,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_t6963.c
+++ b/src/clib/u8g_com_arduino_t6963.c
@@ -61,7 +61,7 @@
 
 #include "u8g.h"
 
-#if  defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 //#include <WProgram.h>

--- a/src/clib/u8g_com_stm32duino_ssd_i2c_fn.cpp
+++ b/src/clib/u8g_com_stm32duino_ssd_i2c_fn.cpp
@@ -1,0 +1,94 @@
+/*
+  u8g_com_stm32duino_ssd_i2c_fn.cpp
+
+  communication interface for SSDxxxx chip variant I2C protocol
+*/
+
+#if defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+
+#include "u8g.h"
+#include "Wire.h"
+
+
+/*
+  BUFFER_LENGTH is defined in libraries\Wire\utility\WireBase.h
+  Default value is 32
+  Increate this value to 144 to send U8G_COM_MSG_WRITE_SEQ in single block
+*/
+
+#if defined(BUFFER_LENGTH) && BUFFER_LENGTH < 144
+#define I2C_MAX_LENGTH (BUFFER_LENGTH - 1)
+#endif // BUFFER_LENGTH
+
+
+static uint8_t control = 255;
+
+uint8_t u8g_com_stm32duino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+{
+
+  if (control == 255) {
+    if (msg == U8G_COM_MSG_INIT) {
+      control = 254;
+      }
+    return 1;
+  }
+  if (control == 254) {
+    if (msg != U8G_COM_MSG_INIT) {
+      return 1;
+    } else {
+      control = 0;
+    }
+  }
+
+  switch(msg)
+  {
+    case U8G_COM_MSG_INIT:
+      Wire.setClock(400000);
+      Wire.begin();
+      break;
+
+    case U8G_COM_MSG_ADDRESS:           /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+      if (arg_val == 0) {
+        control = 0x00;
+      } else {
+        control = 0x40;
+      } 
+      break;
+
+    case U8G_COM_MSG_WRITE_BYTE:
+      Wire.beginTransmission(0x3c);
+      Wire.write(control);
+      Wire.write(arg_val);
+      Wire.endTransmission();
+      break;
+
+    case U8G_COM_MSG_WRITE_SEQ:
+      {
+#ifdef I2C_MAX_LENGTH
+      while (arg_val > 0) {
+        Wire.beginTransmission(0x3c);
+        Wire.write(control);
+        if (arg_val <= I2C_MAX_LENGTH) {
+          Wire.write((uint8_t *) arg_ptr, arg_val);
+          arg_val = 0;
+        } else {
+          Wire.write((uint8_t *) arg_ptr, I2C_MAX_LENGTH);
+          arg_val -= I2C_MAX_LENGTH;
+          arg_ptr += I2C_MAX_LENGTH;
+        }
+        Wire.endTransmission();
+      }
+#else
+      Wire.beginTransmission(0x3c);
+      Wire.write(control);
+      Wire.write((uint8_t *) arg_ptr, arg_val);
+      Wire.endTransmission();
+#endif // I2C_MAX_LENGTH
+      break;
+      }
+
+  }
+  return 1;
+}
+
+#endif // defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)

--- a/src/clib/u8g_delay.c
+++ b/src/clib/u8g_delay.c
@@ -44,7 +44,7 @@
 
 /*==== Part 1: Derive suitable delay procedure ====*/
 
-#if defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #  if ARDUINO < 100
 #    include <WProgram.h>

--- a/src/clib/u8g_delay.cpp
+++ b/src/clib/u8g_delay.cpp
@@ -1,0 +1,10 @@
+#if defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+
+#include "u8g.h"
+#include "Arduino.h"
+
+void u8g_Delay(uint16_t val) {
+   delay(val);
+}
+
+#endif // defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)

--- a/src/clib/u8g_delay.cpp
+++ b/src/clib/u8g_delay.cpp
@@ -1,4 +1,4 @@
-#if defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#if defined(ARDUINO) && defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
 
 #include "u8g.h"
 #include "Arduino.h"
@@ -7,4 +7,4 @@ void u8g_Delay(uint16_t val) {
    delay(val);
 }
 
-#endif // defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#endif // defined(ARDUINO) && defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)

--- a/src/clib/u8g_dev_ht1632.c
+++ b/src/clib/u8g_dev_ht1632.c
@@ -93,7 +93,7 @@ Usage:
 #define HT1632_DATA_LEN         8               // Data are 4*2 bits
 #define HT1632_ADDR_LEN         7               // Address are 7 bits
 
-#if defined(ARDUINO)
+#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 #if ARDUINO < 100
 #include <WProgram.h>


### PR DESCRIPTION
### Description

Add support for SSD1306 and SH1106 I2C displays for STM32F1 and STM32F4.

Tested on STM32F103C8T6 board with 1.3" SH1106 and 0.96" SSD1306 I2C displays.

### Benefits

STM32F1-based systems can use I2C OLED displays based on SSD1306 and SH1106 controllers.


### Additional information

The binary.h file required by lcd/dogm/dogm_bitmaps.h is not present in stm32duino environment.
Binary macro are defined in other file in stm32duino, so binary.h needs to be created in HAL_STM32F1
either empty or with following code
`#include "bit_constants.h"`

Including Arduino.h from .c u8glib file causes compilation errors on stm32duino.
Including Arduino.h from .cpp works just fine.

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/11583