### PR TITLE
Add support for STM32 Core and fix compilation problems for Maple

### DIFF
--- a/src/clib/u8g.h
+++ b/src/clib/u8g.h
@@ -762,7 +762,7 @@ defined(__18CXX) || defined(__PIC32MX)
 #endif
 
 #ifndef U8G_COM_HW_SPI
-#if defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#if defined(ARDUINO_ARCH_STM32)
 #define U8G_COM_HW_SPI u8g_com_stm32duino_hw_spi_fn
 #define U8G_COM_ST7920_HW_SPI u8g_com_null_fn
 #endif
@@ -860,7 +860,7 @@ defined(__18CXX) || defined(__PIC32MX)
 #endif
 
 #ifndef U8G_COM_SSD_I2C
-#if defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#if defined(ARDUINO_ARCH_STM32)
 #define U8G_COM_SSD_I2C u8g_com_stm32duino_ssd_i2c_fn
 #endif
 #endif

--- a/src/clib/u8g_com_arduino_common.c
+++ b/src/clib/u8g_com_arduino_common.c
@@ -38,7 +38,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -71,5 +71,3 @@ void u8g_com_arduino_assign_pin_output_high(u8g_t *u8g)
 
 
 #endif
-
-

--- a/src/clib/u8g_com_arduino_fast_parallel.c
+++ b/src/clib/u8g_com_arduino_fast_parallel.c
@@ -59,7 +59,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 //#include <WProgram.h>
@@ -251,4 +251,3 @@ uint8_t u8g_com_arduino_fast_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
 
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_arduino_no_en_parallel.c
+++ b/src/clib/u8g_com_arduino_no_en_parallel.c
@@ -59,7 +59,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 //#include <WProgram.h>
@@ -231,4 +231,3 @@ uint8_t u8g_com_arduino_no_en_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_v
 
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_arduino_parallel.c
+++ b/src/clib/u8g_com_arduino_parallel.c
@@ -55,7 +55,7 @@
 #include "u8g.h"
 
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -181,4 +181,3 @@ uint8_t u8g_com_arduino_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, vo
 }
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_arduino_port_d_wr.c
+++ b/src/clib/u8g_com_arduino_port_d_wr.c
@@ -54,7 +54,7 @@
 #include "u8g.h"
 
 
-#if defined(ARDUINO) && defined(PORTD) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && defined(PORTD) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -174,4 +174,3 @@ uint8_t u8g_com_arduino_port_d_wr_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, v
 }
 
 #endif /* ARDUINO && PORTD */
-

--- a/src/clib/u8g_com_arduino_st7920_custom.c
+++ b/src/clib/u8g_com_arduino_st7920_custom.c
@@ -47,7 +47,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -327,4 +327,3 @@ uint8_t u8g_com_arduino_st7920_custom_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
 }
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_arduino_st7920_hw_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_hw_spi.c
@@ -37,7 +37,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -290,4 +290,3 @@ uint8_t u8g_com_arduino_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
 }
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_arduino_st7920_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_spi.c
@@ -44,7 +44,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -327,4 +327,3 @@ uint8_t u8g_com_arduino_st7920_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
 }
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_arduino_std_sw_spi.c
+++ b/src/clib/u8g_com_arduino_std_sw_spi.c
@@ -36,7 +36,7 @@
 #include "u8g.h"
 
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -140,4 +140,3 @@ uint8_t u8g_com_arduino_std_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
 }
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_arduino_sw_spi.c
+++ b/src/clib/u8g_com_arduino_sw_spi.c
@@ -42,7 +42,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -298,4 +298,3 @@ uint8_t u8g_com_arduino_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void
 }
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_arduino_t6963.c
+++ b/src/clib/u8g_com_arduino_t6963.c
@@ -61,7 +61,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && ! (defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 //#include <WProgram.h>
@@ -400,4 +400,3 @@ uint8_t u8g_com_arduino_t6963_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
 
 
 #endif /* ARDUINO */
-

--- a/src/clib/u8g_com_io.cpp
+++ b/src/clib/u8g_com_io.cpp
@@ -287,16 +287,37 @@
     return digitalRead(internal_pin_number);
   }
 
-#elif defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#elif defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
 
   #include <Arduino.h>
   #include "libmaple/gpio.h"
+
   void u8g_SetPinOutput(uint8_t IO) {
     gpio_set_mode(PIN_MAP[IO].gpio_device, PIN_MAP[IO].gpio_bit, GPIO_OUTPUT_PP);
   }
 
   void u8g_SetPinLevel(uint8_t IO, uint8_t V) {
     PIN_MAP[IO].gpio_device->regs->BSRR = (1U << PIN_MAP[IO].gpio_bit) << (16 * !(bool)V);
+  }
+
+#elif defined(ARDUINO_ARCH_STM32)
+
+  #include "wiring.h"
+
+  void u8g_SetPinOutput(uint8_t internal_pin_number) {
+    pinMode(internal_pin_number, OUTPUT);
+  }
+
+  void u8g_SetPinInput(uint8_t internal_pin_number) {
+    pinMode(internal_pin_number, INPUT);
+  }
+
+  void u8g_SetPinLevel(uint8_t internal_pin_number, uint8_t level) {
+    digitalWrite(internal_pin_number, level);
+  }
+
+  uint8_t u8g_GetPinLevel(uint8_t internal_pin_number) {
+    return digitalRead(internal_pin_number);
   }
 
 #elif defined(U8G_HAL_LINKS)

--- a/src/clib/u8g_com_stm32duino_hw_spi.cpp
+++ b/src/clib/u8g_com_stm32duino_hw_spi.cpp
@@ -4,7 +4,7 @@
   communication interface for SPI protocol
 */
 
-#if defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#if defined(ARDUINO_ARCH_STM32)
 
 #include "u8g.h"
 #include "SPI.h"
@@ -55,17 +55,26 @@ uint8_t u8g_com_stm32duino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, v
 
     case U8G_COM_MSG_WRITE_BYTE:
       SPI.beginTransaction(spiConfig);
-      SPI.send(arg_val);
+      #if defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
+        SPI.send(arg_val);
+      #else
+        SPI.transfer(arg_val);
+      #endif
       SPI.endTransaction();
       break;
 
     case U8G_COM_MSG_WRITE_SEQ:
       SPI.beginTransaction(spiConfig);
-      SPI.send((uint8_t *)arg_ptr, arg_val);
+      #if defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
+        SPI.send((uint8_t *)arg_ptr, arg_val);
+      #else
+        SPI.transfer((uint8_t *)arg_ptr, arg_val);
+      #endif
       SPI.endTransaction();
       break;
   }
   return 1;
 }
 
-#endif // defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#endif // ARDUINO_ARCH_STM32
+

--- a/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
+++ b/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
@@ -4,7 +4,7 @@
   communication interface for SSDxxxx chip variant I2C protocol
 */
 
-#if defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx)
+#if defined(ARDUINO_ARCH_STM32)
 
 #include "u8g.h"
 #include "Wire.h"
@@ -77,4 +77,4 @@ uint8_t u8g_com_stm32duino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
   return 1;
 }
 
-#endif // STM32F1 || STM32F1xx || STM32F4 || STM32F4xx
+#endif // ARDUINO_ARCH_STM32

--- a/src/clib/u8g_dev_ht1632.c
+++ b/src/clib/u8g_dev_ht1632.c
@@ -93,7 +93,7 @@ Usage:
 #define HT1632_DATA_LEN         8               // Data are 4*2 bits
 #define HT1632_ADDR_LEN         7               // Address are 7 bits
 
-#if defined(ARDUINO) && !(defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
 
 #if ARDUINO < 100
 #include <WProgram.h>


### PR DESCRIPTION
### Description

Add support for STM32 Core used by HAL_STM32.
Fix compilation problem for Maple used by HAL_STM32F1 and HAL_STM32F4.

Tested on STM32F407VET6 and HAL_STM32
https://3dtoday.ru/upload/resize_cache/main/e4e/940_1080_1/e4e655d7ffd8efe6b120aea703a06093.jpg

### Benefits

STM32-based systems can use graphics displays once again.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/13489
