### PR TITLE
Fix i2c warnings

### DIFF
--- a/src/clib/u8g_com_i2c.c
+++ b/src/clib/u8g_com_i2c.c
@@ -622,6 +622,7 @@ uint8_t u8g_i2c_wait(uint8_t mask, uint8_t pos)
 
 void u8g_i2c_init(uint8_t options)
 {
+  u8g_i2c_opt = options;
   u8g_i2c_clear_error();
 }
 

--- a/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
+++ b/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
@@ -49,25 +49,26 @@ uint8_t u8g_com_stm32duino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
 
     case U8G_COM_MSG_WRITE_SEQ:
     {
+      uint8_t* dataptr = (uint8_t*) arg_ptr;
       #ifdef I2C_MAX_LENGTH
         while (arg_val > 0) {
           Wire.beginTransmission(0x3c);
           Wire.write(control);
           if (arg_val <= I2C_MAX_LENGTH) {
-            Wire.write((uint8_t *) arg_ptr, arg_val);
+            Wire.write(dataptr, arg_val);
             arg_val = 0;
           }
           else {
-            Wire.write((uint8_t *) arg_ptr, I2C_MAX_LENGTH);
+            Wire.write(dataptr, I2C_MAX_LENGTH);
             arg_val -= I2C_MAX_LENGTH;
-            arg_ptr += I2C_MAX_LENGTH;
+            dataptr += I2C_MAX_LENGTH;
           }
           Wire.endTransmission();
         }
       #else
         Wire.beginTransmission(0x3c);
         Wire.write(control);
-        Wire.write((uint8_t *) arg_ptr, arg_val);
+        Wire.write(dataptr, arg_val);
         Wire.endTransmission();
       #endif // I2C_MAX_LENGTH
       break;

--- a/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
+++ b/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
@@ -49,7 +49,7 @@ uint8_t u8g_com_stm32duino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
 
     case U8G_COM_MSG_WRITE_SEQ:
     {
-      uint8_t* dataptr = (uint8_t*) arg_ptr;
+      uint8_t* dataptr = (uint8_t*)arg_ptr;
       #ifdef I2C_MAX_LENGTH
         while (arg_val > 0) {
           Wire.beginTransmission(0x3c);


### PR DESCRIPTION
  src/clib/u8g_com_stm32duino_ssd_i2c.cpp:63:21:

  In function 'uint8_t u8g_com_stm32duino_ssd_i2c_fn':
  warning: pointer of type 'void *' used in arithmetic [-Wpointer-arith]
  arg_ptr += I2C_MAX_LENGTH;