### PR TITLE
Fix warning when building on LPC176x.

### DIFF
--- a/src/clib/u8g_com_i2c.c
+++ b/src/clib/u8g_com_i2c.c
@@ -41,12 +41,13 @@
 //#define U8G_I2C_WITH_NO_ACK
 
 static uint8_t u8g_i2c_err_code;
-#if defined(U8G_RASPBERRY_PI) || \
-    (defined(ARDUINO) && defined(__SAM3X8E__)) || \
-    defined(U8G_RASPBERRY_PI) || \
-    !defined(U8G_HAL_LINKS)
-    static uint8_t u8g_i2c_opt;   /* U8G_I2C_OPT_NO_ACK, SAM: U8G_I2C_OPT_DEV_1 */
+
+#if defined(U8G_RASPBERRY_PI) \
+  || (defined(ARDUINO) && defined(__SAM3X8E__)) \
+  || !defined(U8G_HAL_LINKS)
+  static uint8_t u8g_i2c_opt;   /* U8G_I2C_OPT_NO_ACK, SAM: U8G_I2C_OPT_DEV_1 */
 #endif
+
 /*
   position values
     1: start condition

--- a/src/clib/u8g_com_i2c.c
+++ b/src/clib/u8g_com_i2c.c
@@ -41,7 +41,12 @@
 //#define U8G_I2C_WITH_NO_ACK
 
 static uint8_t u8g_i2c_err_code;
-static uint8_t u8g_i2c_opt;   /* U8G_I2C_OPT_NO_ACK, SAM: U8G_I2C_OPT_DEV_1 */
+#if defined(U8G_RASPBERRY_PI) || \
+    (defined(ARDUINO) && defined(__SAM3X8E__)) || \
+    defined(U8G_RASPBERRY_PI) || \
+    !defined(U8G_HAL_LINKS)
+    static uint8_t u8g_i2c_opt;   /* U8G_I2C_OPT_NO_ACK, SAM: U8G_I2C_OPT_DEV_1 */
+#endif
 /*
   position values
     1: start condition


### PR DESCRIPTION
Fix the `u8g_i2c_opt` warning on LPC176x.