### PR TITLE
Support STM32F1 after maple update

### DIFF
--- a/src/clib/u8g.h
+++ b/src/clib/u8g.h
@@ -766,7 +766,7 @@ defined(__18CXX) || defined(__PIC32MX)
 #endif
 
 #ifndef U8G_COM_HW_SPI
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_STM32F1)
 #define U8G_COM_HW_SPI u8g_com_stm32duino_hw_spi_fn
 #define U8G_COM_ST7920_HW_SPI u8g_com_null_fn
 #endif
@@ -871,7 +871,7 @@ defined(__18CXX) || defined(__PIC32MX)
 #endif
 
 #ifndef U8G_COM_SSD_I2C
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_STM32F1)
 #define U8G_COM_SSD_I2C u8g_com_stm32duino_ssd_i2c_fn
 #endif
 #endif

--- a/src/clib/u8g_com_arduino_common.c
+++ b/src/clib/u8g_com_arduino_common.c
@@ -38,7 +38,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_fast_parallel.c
+++ b/src/clib/u8g_com_arduino_fast_parallel.c
@@ -59,7 +59,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 //#include <WProgram.h>

--- a/src/clib/u8g_com_arduino_no_en_parallel.c
+++ b/src/clib/u8g_com_arduino_no_en_parallel.c
@@ -59,7 +59,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 //#include <WProgram.h>

--- a/src/clib/u8g_com_arduino_parallel.c
+++ b/src/clib/u8g_com_arduino_parallel.c
@@ -55,7 +55,7 @@
 #include "u8g.h"
 
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_port_d_wr.c
+++ b/src/clib/u8g_com_arduino_port_d_wr.c
@@ -54,7 +54,7 @@
 #include "u8g.h"
 
 
-#if defined(ARDUINO) && defined(PORTD) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && defined(PORTD) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_st7920_custom.c
+++ b/src/clib/u8g_com_arduino_st7920_custom.c
@@ -47,7 +47,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_st7920_hw_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_hw_spi.c
@@ -37,7 +37,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_st7920_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_spi.c
@@ -44,7 +44,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_std_sw_spi.c
+++ b/src/clib/u8g_com_arduino_std_sw_spi.c
@@ -36,7 +36,7 @@
 #include "u8g.h"
 
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_sw_spi.c
+++ b/src/clib/u8g_com_arduino_sw_spi.c
@@ -42,7 +42,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_t6963.c
+++ b/src/clib/u8g_com_arduino_t6963.c
@@ -61,7 +61,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 #if ARDUINO < 100
 //#include <WProgram.h>

--- a/src/clib/u8g_com_stm32duino_hw_spi.cpp
+++ b/src/clib/u8g_com_stm32duino_hw_spi.cpp
@@ -4,7 +4,7 @@
   communication interface for SPI protocol
 */
 
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_STM32F1)
 
 #include "u8g.h"
 #include "SPI.h"
@@ -30,7 +30,7 @@ uint8_t u8g_com_stm32duino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, v
       u8g_SetPIOutput(u8g, U8G_PI_RESET);
 
       u8g_SetPILevel(u8g, U8G_PI_CS, 1);
-      
+
       spiConfig = SPISettings(2500000, MSBFIRST, SPI_MODE0); // 2.5 Mbits base clock
       SPI.begin();
       break;

--- a/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
+++ b/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
@@ -4,7 +4,7 @@
   communication interface for SSDxxxx chip variant I2C protocol
 */
 
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_STM32F1)
 
 #include "u8g.h"
 #include "Wire.h"

--- a/src/clib/u8g_dev_ht1632.c
+++ b/src/clib/u8g_dev_ht1632.c
@@ -62,7 +62,7 @@ Usage:
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
   #if ARDUINO < 100
     #include <WProgram.h>
   #else
@@ -101,7 +101,7 @@ Usage:
 #define HT1632_DATA_LEN         8               // Data are 4*2 bits
 #define HT1632_ADDR_LEN         7               // Address are 7 bits
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM32F1)
 
 //#define WR_PIN 3
 //#define DATA_PIN 2


### PR DESCRIPTION
This makes U8glib work without having to define `ARDUINO_ARCH_STM32`, as currently in https://github.com/MarlinFirmware/Marlin/pull/20325.