### PR TITLE
Update u8g_ll_api.c

### DIFF
--- a/src/clib/u8g_ll_api.c
+++ b/src/clib/u8g_ll_api.c
@@ -252,7 +252,8 @@ uint8_t u8g_InitSPI(u8g_t *u8g, u8g_dev_t *dev, uint8_t sck, uint8_t mosi, uint8
   /* if - in future releases - this is removed, then still call u8g_UpdateDimension() */
   /* if Arduino call u8g_UpdateDimension else u8g_Begin */
   /* issue 146 */
-  return u8g_Begin(u8g);
+  u8g_UpdateDimension(u8g);
+  return 1;
 }
 
 uint8_t u8g_InitHWSPI(u8g_t *u8g, u8g_dev_t *dev, uint8_t cs, uint8_t a0, uint8_t reset)

--- a/src/clib/u8g_ll_api.c
+++ b/src/clib/u8g_ll_api.c
@@ -204,7 +204,12 @@ uint8_t u8g_Init(u8g_t *u8g, u8g_dev_t *dev)
   /* if - in future releases - this is removed, then still call u8g_UpdateDimension() */
   /* if Arduino call u8g_UpdateDimension else u8g_Begin */
   /* issue 146 */
-  return u8g_Begin(u8g);
+  #ifdef ARDUINO
+    u8g_UpdateDimension(u8g);
+    return 1;
+  #else
+    return u8g_Begin(u8g);
+  #endif
 }
 
 /* special init for pure ARM systems */
@@ -229,7 +234,12 @@ uint8_t u8g_InitComFn(u8g_t *u8g, u8g_dev_t *dev, u8g_com_fnptr com_fn)
   /* if - in future releases - this is removed, then still call u8g_UpdateDimension() */
   /* if Arduino call u8g_UpdateDimension else u8g_Begin */
   /* issue 146 */
-  return u8g_Begin(u8g);
+  #ifdef ARDUINO
+    u8g_UpdateDimension(u8g);
+    return 1;
+  #else
+    return u8g_Begin(u8g);
+  #endif
 }
 
 
@@ -252,8 +262,12 @@ uint8_t u8g_InitSPI(u8g_t *u8g, u8g_dev_t *dev, uint8_t sck, uint8_t mosi, uint8
   /* if - in future releases - this is removed, then still call u8g_UpdateDimension() */
   /* if Arduino call u8g_UpdateDimension else u8g_Begin */
   /* issue 146 */
-  u8g_UpdateDimension(u8g);
-  return 1;
+  #ifdef ARDUINO
+    u8g_UpdateDimension(u8g);
+    return 1;
+  #else
+    return u8g_Begin(u8g);
+  #endif
 }
 
 uint8_t u8g_InitHWSPI(u8g_t *u8g, u8g_dev_t *dev, uint8_t cs, uint8_t a0, uint8_t reset)


### PR DESCRIPTION
Replace u8g_Begin with u8g_UpdateDimension per comment to prevent 2 calls to u8g_Begin:
```
  /* On the Arduino Environment this will lead to two calls to u8g_Begin(), the following line will be called first (by U8glib constructors) */
  /* if - in future releases - this is removed, then still call u8g_UpdateDimension() */
  /* if Arduino call u8g_UpdateDimension else u8g_Begin */
  /* issue 146 */
```
This fixes pin 0 config when u8g_Begin is called twice.
May affect other inits but only tested this change on my board.

See Marlin Issue MarlinFirmware/Marlin#21277 and PR MarlinFirmware/Marlin#21417 for more info.
