### PR TITLE
Remove explicit U8G_NOINLINE.

### DIFF
--- a/src/clib/u8g.h
+++ b/src/clib/u8g.h
@@ -71,7 +71,6 @@ extern "C" {
 
 /*===============================================================*/
 #ifdef __GNUC__
-#  define U8G_NOINLINE __attribute__((noinline))
 #  define U8G_PURE  __attribute__ ((pure))
 #  define U8G_NOCOMMON __attribute__ ((nocommon))
 #  define U8G_SECTION(name) __attribute__ ((section (name)))
@@ -83,7 +82,6 @@ extern "C" {
 #    define U8G_FONT_SECTION(name) U8G_SECTION(".progmem." name)
 #  endif
 #else
-#  define U8G_NOINLINE
 #  define U8G_PURE
 #  define U8G_NOCOMMON
 #  define U8G_SECTION(name)
@@ -972,9 +970,9 @@ struct _u8g_page_t
 };
 typedef struct _u8g_page_t u8g_page_t;
 
-void u8g_page_First(u8g_page_t *p) U8G_NOINLINE;                                                                                        /* u8g_page.c */
-void u8g_page_Init(u8g_page_t *p, u8g_uint_t page_height, u8g_uint_t total_height ) U8G_NOINLINE;            /* u8g_page.c */
-uint8_t u8g_page_Next(u8g_page_t *p) U8G_NOINLINE;                                                                                   /* u8g_page.c */
+void u8g_page_First(u8g_page_t *p);                                                                                        /* u8g_page.c */
+void u8g_page_Init(u8g_page_t *p, u8g_uint_t page_height, u8g_uint_t total_height );            /* u8g_page.c */
+uint8_t u8g_page_Next(u8g_page_t *p);                                                                                   /* u8g_page.c */
 
 /*===============================================================*/
 /* page buffer (pb) */
@@ -1016,8 +1014,8 @@ u8g_pb_t name##_pb = { {page_height, height, 0, 0, 0},  width, name##_buf}; \
 u8g_dev_t name = { dev_fn, &name##_pb, com_fn }
 
 
-void u8g_pb8v1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width)   U8G_NOINLINE;
-void u8g_pb8v1_Clear(u8g_pb_t *b) U8G_NOINLINE;
+void u8g_pb8v1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width);
+void u8g_pb8v1_Clear(u8g_pb_t *b);
 
 uint8_t u8g_pb8v1_IsYIntersection(u8g_pb_t *b, u8g_uint_t v0, u8g_uint_t v1);
 uint8_t u8g_pb8v1_IsXIntersection(u8g_pb_t *b, u8g_uint_t v0, u8g_uint_t v1);
@@ -1289,8 +1287,8 @@ void u8g_SetScale2x2(u8g_t *u8g);
 /* u8g_font.c */
 
 size_t u8g_font_GetSize(const void *font);
-uint8_t u8g_font_GetFontStartEncoding(const void *font) U8G_NOINLINE;
-uint8_t u8g_font_GetFontEndEncoding(const void *font) U8G_NOINLINE;
+uint8_t u8g_font_GetFontStartEncoding(const void *font);
+uint8_t u8g_font_GetFontEndEncoding(const void *font);
 
 void u8g_SetFont(u8g_t *u8g, const u8g_fntpgm_uint8_t *font);
 
@@ -1346,7 +1344,7 @@ u8g_uint_t u8g_GetStrPixelWidth(u8g_t *u8g, const char *s);
 u8g_uint_t u8g_GetStrPixelWidthP(u8g_t *u8g, const u8g_pgm_uint8_t *s);
 int8_t u8g_GetStrX(u8g_t *u8g, const char *s);
 int8_t u8g_GetStrXP(u8g_t *u8g, const u8g_pgm_uint8_t *s);
-u8g_uint_t u8g_GetStrWidth(u8g_t *u8g, const char *s) U8G_NOINLINE;
+u8g_uint_t u8g_GetStrWidth(u8g_t *u8g, const char *s);
 u8g_uint_t u8g_GetStrWidthP(u8g_t *u8g, const u8g_pgm_uint8_t *s);
 
 u8g_uint_t u8g_DrawStrFontBBX(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, uint8_t dir, const char *s);
@@ -1359,15 +1357,15 @@ u8g_uint_t u8g_DrawAAStr(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, const char *s);
 
 /* u8g_rect.c */
 
-void u8g_draw_box(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h) U8G_NOINLINE;
+void u8g_draw_box(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h);
 
-void u8g_DrawHLine(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w) U8G_NOINLINE;
-void u8g_DrawVLine(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w) U8G_NOINLINE;
-void u8g_DrawFrame(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h) U8G_NOINLINE;
-void u8g_DrawBox(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h) U8G_NOINLINE;
+void u8g_DrawHLine(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w);
+void u8g_DrawVLine(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w);
+void u8g_DrawFrame(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h);
+void u8g_DrawBox(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h);
 
-void u8g_DrawRFrame(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h, u8g_uint_t r) U8G_NOINLINE;
-void u8g_DrawRBox(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h, u8g_uint_t r) U8G_NOINLINE;
+void u8g_DrawRFrame(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h, u8g_uint_t r);
+void u8g_DrawRBox(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h, u8g_uint_t r);
 
 /* u8g_bitmap.c */
 
@@ -1403,8 +1401,8 @@ void u8g_DrawEllipseRect(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t x1
 #define U8G_DRAW_LOWER_RIGHT  0x08
 #define U8G_DRAW_ALL (U8G_DRAW_UPPER_RIGHT|U8G_DRAW_UPPER_LEFT|U8G_DRAW_LOWER_RIGHT|U8G_DRAW_LOWER_LEFT)
 
-void u8g_draw_circle(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rad, uint8_t option) U8G_NOINLINE;
-void u8g_draw_disc(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rad, uint8_t option) U8G_NOINLINE;
+void u8g_draw_circle(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rad, uint8_t option);
+void u8g_draw_disc(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rad, uint8_t option);
 
 void u8g_DrawCircle(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rad, uint8_t option);
 void u8g_DrawDisc(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rad, uint8_t option);
@@ -1429,8 +1427,6 @@ void u8g_DrawCursor(u8g_t *u8g);
 /* u8g_polygon.c */
 
 typedef int16_t pg_word_t;
-
-#define PG_NOINLINE U8G_NOINLINE
 
 struct pg_point_struct
 {
@@ -1510,15 +1506,15 @@ void st_Step(uint8_t player_pos, uint8_t is_auto_fire, uint8_t is_fire);
 #define U8G_I2C_ERR_TIMEOUT 0x01
 #define U8G_I2C_ERR_BUS 0x02
 
-void u8g_i2c_clear_error(void) U8G_NOINLINE;
-uint8_t  u8g_i2c_get_error(void) U8G_NOINLINE;
-uint8_t u8g_i2c_get_err_pos(void) U8G_NOINLINE;
-void u8g_i2c_init(uint8_t options) U8G_NOINLINE;    /* use U8G_I2C_OPT_NONE as options */
-uint8_t u8g_i2c_wait(uint8_t mask, uint8_t pos) U8G_NOINLINE;
-uint8_t u8g_i2c_start(uint8_t sla) U8G_NOINLINE;
-uint8_t u8g_i2c_send_byte(uint8_t data) U8G_NOINLINE;
-uint8_t u8g_i2c_send_mode(uint8_t mode) U8G_NOINLINE;
-void u8g_i2c_stop(void) U8G_NOINLINE;
+void u8g_i2c_clear_error(void);
+uint8_t  u8g_i2c_get_error(void);
+uint8_t u8g_i2c_get_err_pos(void);
+void u8g_i2c_init(uint8_t options);    /* use U8G_I2C_OPT_NONE as options */
+uint8_t u8g_i2c_wait(uint8_t mask, uint8_t pos);
+uint8_t u8g_i2c_start(uint8_t sla);
+uint8_t u8g_i2c_send_byte(uint8_t data);
+uint8_t u8g_i2c_send_mode(uint8_t mode);
+void u8g_i2c_stop(void);
 
 
 /*===============================================================*/

--- a/src/clib/u8g_circle.c
+++ b/src/clib/u8g_circle.c
@@ -203,8 +203,6 @@ void u8g_DrawFillCirc(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rad, 
 
 /*=========================================================================*/
 
-static void u8g_draw_circle_section(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t x0, u8g_uint_t y0, uint8_t option) U8G_NOINLINE;
-
 static void u8g_draw_circle_section(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t x0, u8g_uint_t y0, uint8_t option)
 {
     /* upper right */
@@ -289,8 +287,6 @@ void u8g_DrawCircle(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rad, ui
   /* draw circle */
   u8g_draw_circle(u8g, x0, y0, rad, option);
 }
-
-static void u8g_draw_disc_section(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t x0, u8g_uint_t y0, uint8_t option) U8G_NOINLINE;
 
 static void u8g_draw_disc_section(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t x0, u8g_uint_t y0, uint8_t option)
 {

--- a/src/clib/u8g_com_arduino_hw_spi.c
+++ b/src/clib/u8g_com_arduino_hw_spi.c
@@ -176,7 +176,6 @@ typedef struct {
 
 
 
-//static uint8_t u8g_spi_out(uint8_t data) U8G_NOINLINE;
 static uint8_t u8g_spi_out(uint8_t data)
 {
   /* unsigned char x = 100; */

--- a/src/clib/u8g_com_arduino_st7920_custom.c
+++ b/src/clib/u8g_com_arduino_st7920_custom.c
@@ -80,7 +80,6 @@ static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
   u8g_bitNotData ^= 0x0ff;
 }
 
-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val) U8G_NOINLINE;
 static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
 {
   uint8_t cnt = 8;

--- a/src/clib/u8g_com_arduino_st7920_hw_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_hw_spi.c
@@ -95,7 +95,6 @@
 #endif
 
 
-static uint8_t u8g_arduino_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
 static uint8_t u8g_arduino_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val)
 {
   /* send data */
@@ -136,7 +135,6 @@ static void u8g_com_arduino_st7920_write_byte_hw_spi_seq(u8g_t *u8g, uint8_t rs,
     u8g_10MicroDelay();
 }
 
-static void u8g_com_arduino_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val) U8G_NOINLINE;
 static void u8g_com_arduino_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val)
 {
   uint8_t i;

--- a/src/clib/u8g_com_arduino_st7920_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_spi.c
@@ -77,7 +77,6 @@ static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
   u8g_bitNotData ^= 0x0ff;
 }
 
-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val) U8G_NOINLINE;
 static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
 {
   uint8_t cnt = 8;

--- a/src/clib/u8g_com_arduino_sw_spi.c
+++ b/src/clib/u8g_com_arduino_sw_spi.c
@@ -78,7 +78,6 @@ static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
   u8g_bitNotData ^= 0x0ff;
 }
 
-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val) U8G_NOINLINE;
 static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
 {
   uint8_t cnt = 8;

--- a/src/clib/u8g_com_atmega_parallel.c
+++ b/src/clib/u8g_com_atmega_parallel.c
@@ -56,7 +56,6 @@
 
 #ifdef __AVR__
 
-static void u8g_com_atmega_parallel_write(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
 static void u8g_com_atmega_parallel_write(u8g_t *u8g, uint8_t val)
 {
 

--- a/src/clib/u8g_com_atmega_st7920_hw_spi.c
+++ b/src/clib/u8g_com_atmega_st7920_hw_spi.c
@@ -68,7 +68,6 @@
 #include <avr/interrupt.h>
 #include <avr/io.h>
 
-static uint8_t u8g_atmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
 static uint8_t u8g_atmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val)
 {
   /* send data */
@@ -81,7 +80,6 @@ static uint8_t u8g_atmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val)
 }
 
 
-static void u8g_com_atmega_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val) U8G_NOINLINE;
 static void u8g_com_atmega_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val)
 {
   uint8_t i;

--- a/src/clib/u8g_com_atmega_st7920_spi.c
+++ b/src/clib/u8g_com_atmega_st7920_spi.c
@@ -39,7 +39,6 @@
 
 #ifdef __AVR__
 
-static void u8g_atmega_st7920_sw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
 static void u8g_atmega_st7920_sw_spi_shift_out(u8g_t *u8g, uint8_t val)
 {
   uint8_t i = 8;
@@ -55,7 +54,6 @@ static void u8g_atmega_st7920_sw_spi_shift_out(u8g_t *u8g, uint8_t val)
   } while( i != 0 );
 }
 
-static void u8g_com_atmega_st7920_write_byte(u8g_t *u8g, uint8_t rs, uint8_t val) U8G_NOINLINE;
 static void u8g_com_atmega_st7920_write_byte(u8g_t *u8g, uint8_t rs, uint8_t val)
 {
   uint8_t i;

--- a/src/clib/u8g_com_atmega_sw_spi.c
+++ b/src/clib/u8g_com_atmega_sw_spi.c
@@ -38,7 +38,6 @@
 
 #ifdef __AVR__
 
-static void u8g_atmega_sw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
 static void u8g_atmega_sw_spi_shift_out(u8g_t *u8g, uint8_t val)
 {
   uint8_t i = 8;

--- a/src/clib/u8g_com_atxmega_st7920_hw_spi.c
+++ b/src/clib/u8g_com_atxmega_st7920_hw_spi.c
@@ -59,7 +59,6 @@
 #include <avr/interrupt.h>
 #include <avr/io.h>
 
-static uint8_t u8g_atxmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
 static uint8_t u8g_atxmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val)
 {
   /* send data */
@@ -73,7 +72,6 @@ static uint8_t u8g_atxmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val)
 }
 
 
-static void u8g_com_atxmega_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val) U8G_NOINLINE;
 static void u8g_com_atxmega_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val)
 {
   uint8_t i;

--- a/src/clib/u8g_ellipse.c
+++ b/src/clib/u8g_ellipse.c
@@ -110,7 +110,6 @@ typedef  int16_t u8g_long_t;
     ftp://pc.fk0.name/pub/books/programming/bezier-ellipse.pdf
     Foley, Computer Graphics, p 90
 */
-static void u8g_draw_ellipse_section(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t x0, u8g_uint_t y0, uint8_t option) U8G_NOINLINE;
 static void u8g_draw_ellipse_section(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t x0, u8g_uint_t y0, uint8_t option)
 {
     /* upper right */
@@ -251,7 +250,6 @@ void u8g_DrawEllipse(u8g_t *u8g, u8g_uint_t x0, u8g_uint_t y0, u8g_uint_t rx, u8
   u8g_draw_ellipse(u8g, x0, y0, rx, ry, option);
 }
 
-static void u8g_draw_filled_ellipse_section(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t x0, u8g_uint_t y0, uint8_t option) U8G_NOINLINE;
 static void u8g_draw_filled_ellipse_section(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t x0, u8g_uint_t y0, uint8_t option)
 {
     /* upper right */

--- a/src/clib/u8g_font.c
+++ b/src/clib/u8g_font.c
@@ -83,15 +83,12 @@ void u8g_font_GetStrMinBox(u8g_t *u8g, const void *font, const char *s, u8g_uint
 /*========================================================================*/
 /* low level byte and word access */
 
-/* removed NOINLINE, because it leads to smaller code, might also be faster */
-//static uint8_t u8g_font_get_byte(const u8g_fntpgm_uint8_t *font, uint8_t offset) U8G_NOINLINE;
 static uint8_t u8g_font_get_byte(const u8g_fntpgm_uint8_t *font, uint8_t offset)
 {
   font += offset;
   return u8g_pgm_read( (u8g_pgm_uint8_t *)font );
 }
 
-static uint16_t u8g_font_get_word(const u8g_fntpgm_uint8_t *font, uint8_t offset) U8G_NOINLINE;
 static uint16_t u8g_font_get_word(const u8g_fntpgm_uint8_t *font, uint8_t offset)
 {
     uint16_t pos;
@@ -106,13 +103,11 @@ static uint16_t u8g_font_get_word(const u8g_fntpgm_uint8_t *font, uint8_t offset
 /*========================================================================*/
 /* direct access on the font */
 
-static uint8_t u8g_font_GetFormat(const u8g_fntpgm_uint8_t *font) U8G_NOINLINE;
 static uint8_t u8g_font_GetFormat(const u8g_fntpgm_uint8_t *font)
 {
   return u8g_font_get_byte(font, 0);
 }
 
-static uint8_t u8g_font_GetFontGlyphStructureSize(const u8g_fntpgm_uint8_t *font) U8G_NOINLINE;
 static uint8_t u8g_font_GetFontGlyphStructureSize(const u8g_fntpgm_uint8_t *font)
 {
   switch(u8g_font_GetFormat(font))
@@ -149,13 +144,11 @@ uint8_t u8g_font_GetCapitalAHeight(const void *font)
   return u8g_font_get_byte(font, 5);
 }
 
-uint16_t u8g_font_GetEncoding65Pos(const void *font) U8G_NOINLINE;
 uint16_t u8g_font_GetEncoding65Pos(const void *font)
 {
     return u8g_font_get_word(font, 6);
 }
 
-uint16_t u8g_font_GetEncoding97Pos(const void *font) U8G_NOINLINE;
 uint16_t u8g_font_GetEncoding97Pos(const void *font)
 {
     return u8g_font_get_word(font, 8);
@@ -254,19 +247,16 @@ uint8_t u8g_GetFontBBXHeight(u8g_t *u8g)
   return u8g_font_GetBBXHeight(u8g->font);
 }
 
-int8_t u8g_GetFontBBXOffX(u8g_t *u8g) U8G_NOINLINE;
 int8_t u8g_GetFontBBXOffX(u8g_t *u8g)
 {
   return u8g_font_GetBBXOffX(u8g->font);
 }
 
-int8_t u8g_GetFontBBXOffY(u8g_t *u8g) U8G_NOINLINE;
 int8_t u8g_GetFontBBXOffY(u8g_t *u8g)
 {
   return u8g_font_GetBBXOffY(u8g->font);
 }
 
-uint8_t u8g_GetFontCapitalAHeight(u8g_t *u8g) U8G_NOINLINE;
 uint8_t u8g_GetFontCapitalAHeight(u8g_t *u8g)
 {
   return u8g_font_GetCapitalAHeight(u8g->font);
@@ -333,7 +323,6 @@ format 1
   }
 }
 
-//void u8g_FillEmptyGlyphCache(u8g_t *u8g) U8G_NOINLINE;
 static void u8g_FillEmptyGlyphCache(u8g_t *u8g)
 {
   u8g->glyph_dx = 0;

--- a/src/clib/u8g_pb14v1.c
+++ b/src/clib/u8g_pb14v1.c
@@ -41,12 +41,6 @@
 #include <string.h>
 
 
-void u8g_pb14v1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width) U8G_NOINLINE;
-void u8g_pb14v1_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index) U8G_NOINLINE;
-void u8g_pb14v1_SetPixel(u8g_pb_t *b, const u8g_dev_arg_pixel_t * const arg_pixel) U8G_NOINLINE ;
-void u8g_pb14v1_Set8PixelStd(u8g_pb_t *b, u8g_dev_arg_pixel_t *arg_pixel) U8G_NOINLINE;
-
-
 void u8g_pb14v1_Clear(u8g_pb_t *b)
 {
   uint8_t *ptr = (uint8_t *)b->buf;

--- a/src/clib/u8g_pb16h1.c
+++ b/src/clib/u8g_pb16h1.c
@@ -44,10 +44,6 @@
 #include <string.h>
 
 
-void u8g_pb16h1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width) U8G_NOINLINE;
-void u8g_pb16h1_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index) U8G_NOINLINE;
-void u8g_pb16h1_SetPixel(u8g_pb_t *b, const u8g_dev_arg_pixel_t * const arg_pixel) U8G_NOINLINE ;
-void u8g_pb16h1_Set8PixelStd(u8g_pb_t *b, u8g_dev_arg_pixel_t *arg_pixel) U8G_NOINLINE;
 uint8_t u8g_dev_pb8h1_base_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
 
 void u8g_pb16h1_Clear(u8g_pb_t *b)

--- a/src/clib/u8g_pb16h2.c
+++ b/src/clib/u8g_pb16h2.c
@@ -62,7 +62,6 @@ void u8g_pb16h2_Init(u8g_pb_t *b, void *buf, u8g_uint_t width)
   u8g_pb16h2_Clear(b);
 }
 
-static void u8g_pb16h2_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index, uint8_t is_or) U8G_NOINLINE;
 static void u8g_pb16h2_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index, uint8_t is_or)
 {
   register uint8_t mask;

--- a/src/clib/u8g_pb16v1.c
+++ b/src/clib/u8g_pb16v1.c
@@ -41,12 +41,6 @@
 #include <string.h>
 
 
-void u8g_pb16v1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width) U8G_NOINLINE;
-void u8g_pb16v1_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index) U8G_NOINLINE;
-void u8g_pb16v1_SetPixel(u8g_pb_t *b, const u8g_dev_arg_pixel_t * const arg_pixel) U8G_NOINLINE ;
-void u8g_pb16v1_Set8PixelStd(u8g_pb_t *b, u8g_dev_arg_pixel_t *arg_pixel) U8G_NOINLINE;
-
-
 void u8g_pb16v1_Clear(u8g_pb_t *b)
 {
   uint8_t *ptr = (uint8_t *)b->buf;

--- a/src/clib/u8g_pb32h1.c
+++ b/src/clib/u8g_pb32h1.c
@@ -44,10 +44,6 @@
 #include <string.h>
 
 
-void u8g_pb32h1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width) U8G_NOINLINE;
-void u8g_pb32h1_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index) U8G_NOINLINE;
-void u8g_pb32h1_SetPixel(u8g_pb_t *b, const u8g_dev_arg_pixel_t * const arg_pixel) U8G_NOINLINE ;
-void u8g_pb32h1_Set8PixelStd(u8g_pb_t *b, u8g_dev_arg_pixel_t *arg_pixel) U8G_NOINLINE;
 uint8_t u8g_dev_pb8h1_base_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
 
 void u8g_pb32h1_Clear(u8g_pb_t *b)

--- a/src/clib/u8g_pb8h1.c
+++ b/src/clib/u8g_pb8h1.c
@@ -57,10 +57,6 @@ void *u8g_buf_lower_limit;
 void *u8g_buf_upper_limit;
 #endif
 
-void u8g_pb8h1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width) U8G_NOINLINE;
-void u8g_pb8h1_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index) U8G_NOINLINE;
-void u8g_pb8h1_SetPixel(u8g_pb_t *b, const u8g_dev_arg_pixel_t * const arg_pixel) U8G_NOINLINE ;
-void u8g_pb8h1_Set8PixelStd(u8g_pb_t *b, u8g_dev_arg_pixel_t *arg_pixel) U8G_NOINLINE;
 uint8_t u8g_dev_pb8h1_base_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
 
 
@@ -77,7 +73,6 @@ struct u8g_pb_h1_struct
 
 static uint8_t u8g_pb8h1_bitmask[8] = { 0x080, 0x040, 0x020, 0x010, 0x008, 0x004, 0x002, 0x001 };
 
-static void u8g_pb8h1_state_right(struct u8g_pb_h1_struct *s)  U8G_NOINLINE;
 static void u8g_pb8h1_state_right(struct u8g_pb_h1_struct *s)
 {
   register u8g_uint_t x;
@@ -114,7 +109,6 @@ static void u8g_pb8h1_state_up(struct u8g_pb_h1_struct *s)
   s->ptr -= s->line_byte_len;
 }
 
-static void u8g_pb8h1_state_init(struct u8g_pb_h1_struct *s, u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y) U8G_NOINLINE;
 static void u8g_pb8h1_state_init(struct u8g_pb_h1_struct *s, u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y)
 {
   u8g_uint_t tmp;
@@ -146,7 +140,6 @@ static void u8g_pb8h1_state_init(struct u8g_pb_h1_struct *s, u8g_pb_t *b, u8g_ui
   s->ptr = ptr;
 }
 
-static void u8g_pb8h1_state_set_pixel(struct u8g_pb_h1_struct *s, uint8_t color_index) U8G_NOINLINE;
 static void u8g_pb8h1_state_set_pixel(struct u8g_pb_h1_struct *s, uint8_t color_index)
 {
 

--- a/src/clib/u8g_pb8h1f.c
+++ b/src/clib/u8g_pb8h1f.c
@@ -44,10 +44,6 @@
 #include <string.h>
 
 
-void u8g_pb8h1f_Init(u8g_pb_t *b, void *buf, u8g_uint_t width) U8G_NOINLINE;
-void u8g_pb8h1f_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index) U8G_NOINLINE;
-void u8g_pb8h1f_SetPixel(u8g_pb_t *b, const u8g_dev_arg_pixel_t * const arg_pixel) U8G_NOINLINE ;
-void u8g_pb8h1f_Set8PixelStd(u8g_pb_t *b, u8g_dev_arg_pixel_t *arg_pixel) U8G_NOINLINE;
 uint8_t u8g_dev_pb8h1f_base_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
 
 

--- a/src/clib/u8g_pb8h2.c
+++ b/src/clib/u8g_pb8h2.c
@@ -47,7 +47,6 @@ void u8g_pb8h2_Init(u8g_pb_t *b, void *buf, u8g_uint_t width)
   u8g_pb_Clear(b);
 }
 
-static void u8g_pb8h2_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index) U8G_NOINLINE;
 static void u8g_pb8h2_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index)
 {
   register uint8_t mask;

--- a/src/clib/u8g_pb8v1.c
+++ b/src/clib/u8g_pb8v1.c
@@ -41,11 +41,6 @@
 #include <string.h>
 
 
-void u8g_pb8v1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width) U8G_NOINLINE;
-void u8g_pb8v1_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index) U8G_NOINLINE;
-void u8g_pb8v1_SetPixel(u8g_pb_t *b, const u8g_dev_arg_pixel_t * const arg_pixel) U8G_NOINLINE ;
-void u8g_pb8v1_Set8PixelStd(u8g_pb_t *b, u8g_dev_arg_pixel_t *arg_pixel) U8G_NOINLINE;
-
 /* Obsolete, usually set by the init of the structure */
 void u8g_pb8v1_Init(u8g_pb_t *b, void *buf, u8g_uint_t width)
 {

--- a/src/clib/u8g_polygon.c
+++ b/src/clib/u8g_polygon.c
@@ -52,15 +52,6 @@
 
 
 /*===========================================*/
-/* procedures, which should not be inlined (save as much flash ROM as possible */
-
-static uint8_t pge_Next(struct pg_edge_struct *pge) PG_NOINLINE;
-static uint8_t pg_inc(pg_struct *pg, uint8_t i) PG_NOINLINE;
-static uint8_t pg_dec(pg_struct *pg, uint8_t i) PG_NOINLINE;
-static void pg_expand_min_y(pg_struct *pg, pg_word_t min_y, uint8_t pge_idx) PG_NOINLINE;
-static void pg_line_init(pg_struct * const pg, uint8_t pge_index) PG_NOINLINE;
-
-/*===========================================*/
 /* line draw algorithm */
 
 static uint8_t pge_Next(struct pg_edge_struct *pge)


### PR DESCRIPTION
The compiler is usually smarter than us when choosing what to inline or
not, especially when -flto is used.

This saves 384 bytes of program memory on my Anet A6.