### PR TITLE
stm32: allow to disable I2C features

### DIFF
--- a/src/clib/u8g.h
+++ b/src/clib/u8g.h
@@ -869,7 +869,7 @@ defined(__18CXX) || defined(__PIC32MX)
 #endif
 
 #ifndef U8G_COM_SSD_I2C
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(HAL_I2C_MODULE_DISABLED)
 #define U8G_COM_SSD_I2C u8g_com_stm32duino_ssd_i2c_fn
 #endif
 #endif

--- a/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
+++ b/src/clib/u8g_com_stm32duino_ssd_i2c.cpp
@@ -4,7 +4,7 @@
   communication interface for SSDxxxx chip variant I2C protocol
 */
 
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(HAL_I2C_MODULE_DISABLED)
 
 #include "u8g.h"
 #include "Wire.h"


### PR DESCRIPTION
with -DHAL_I2C_MODULE_DISABLED and lib_ignore=Wire

The Wire library constructor is configuring pins for I2C, which can be conflicting
if these board pins are used for something else...