### PR TITLE
Make u8g_outClock and friends static

### DIFF
--- a/src/clib/u8g_com_arduino_sw_spi.c
+++ b/src/clib/u8g_com_arduino_sw_spi.c
@@ -59,10 +59,10 @@
 
 #ifdef __AVR__
 
-uint8_t u8g_bitData, u8g_bitNotData;
-uint8_t u8g_bitClock, u8g_bitNotClock;
-volatile uint8_t *u8g_outData;
-volatile uint8_t *u8g_outClock;
+static uint8_t u8g_bitData, u8g_bitNotData;
+static uint8_t u8g_bitClock, u8g_bitNotClock;
+static volatile uint8_t *u8g_outData;
+static volatile uint8_t *u8g_outClock;
 
 static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
 {


### PR DESCRIPTION
This brings [u8g_com_arduino_sw_spi.c](https://github.com/MarlinFirmware/U8glib-HAL/blob/master/src/clib/u8g_com_arduino_sw_spi.c#L62-L65) in line with [u8g_com_arduino_st7920_custom.c](https://github.com/MarlinFirmware/U8glib-HAL/blob/master/src/clib/u8g_com_arduino_st7920_custom.c#L64-L67) and [u8g_com_arduino_st7920_spi.c](https://github.com/MarlinFirmware/U8glib-HAL/blob/master/src/clib/u8g_com_arduino_st7920_spi.c#L61-L64) and avoids a duplicate symbol issue. See https://github.com/MarlinFirmware/Marlin/issues/18368 and https://github.com/MarlinFirmware/Marlin/pull/22826