### PR TITLE
Experimental full buffer in SSD1309

### DIFF
--- a/src/U8glib-HAL.h
+++ b/src/U8glib-HAL.h
@@ -935,6 +935,17 @@ public:
   void init(uint8_t options = U8G_I2C_OPT_NONE) { U8GLIB::init(&u8g_dev_ssd1309_128x64_i2c, options); }
 };
 
+class U8GLIB_SSD1309_128X64_F : public U8GLIB {
+public:
+  U8GLIB_SSD1309_128X64_F() : U8GLIB() { }
+  U8GLIB_SSD1309_128X64_F(uint8_t sck, uint8_t mosi, uint8_t cs, uint8_t a0, uint8_t reset = U8G_PIN_NONE) { init(sck, mosi, cs, a0, reset); }
+  U8GLIB_SSD1309_128X64_F(uint8_t cs, uint8_t a0, uint8_t reset = U8G_PIN_NONE) { init(cs, a0, reset); }
+  U8GLIB_SSD1309_128X64_F(uint8_t options) { init(options); }
+  void init(uint8_t sck, uint8_t mosi, uint8_t cs, uint8_t a0, uint8_t reset = U8G_PIN_NONE) { U8GLIB::init(&u8g_dev_ssd1309_128x64_f_sw_spi, sck, mosi, cs, a0, reset); }
+  void init(uint8_t cs, uint8_t a0, uint8_t reset = U8G_PIN_NONE) { U8GLIB::init(&u8g_dev_ssd1309_128x64_f_hw_spi, cs, a0, reset); }
+  void init(uint8_t options = U8G_I2C_OPT_NONE) { U8GLIB::init(&u8g_dev_ssd1309_128x64_f_i2c, options); }
+};
+
 class U8GLIB_SSD1306_128X32 : public U8GLIB {
 public:
   U8GLIB_SSD1306_128X32() : U8GLIB() { }

--- a/src/clib/u8g_dev_ssd1309_128x64.c
+++ b/src/clib/u8g_dev_ssd1309_128x64.c
@@ -155,15 +155,16 @@ uint8_t u8g_dev_ssd1309_128x64_f_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
     bool is_last_page = pb->p.page == PAGE_COUNT - 1;
     if (is_last_page && page_change_flags) {
       for (uint8_t page = 0; page < PAGE_COUNT; page++) {
-        bool did_page_change = page_change_flags >> pb->p.page & 1;
+        bool did_page_change = page_change_flags >> page & 1;
         if (did_page_change) {
           u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd1309_128x64_data_start);
           u8g_WriteByte(u8g, dev, 0x0b0 | page); /* select current page (SSD1306) */
           u8g_SetAddress(u8g, dev, 1);           /* data mode */
-          if (u8g_WriteSequence(u8g, dev, WIDTH, full_buffer[page]) == 0) return 0;
+          u8g_WriteSequence(u8g, dev, WIDTH, full_buffer[page]);
         }
       }
       u8g_SetChipSelect(u8g, dev, 0);
+      page_change_flags = 0;
     }     
     return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);
   }

--- a/src/clib/u8g_dev_ssd1309_128x64.c
+++ b/src/clib/u8g_dev_ssd1309_128x64.c
@@ -157,8 +157,9 @@ uint8_t u8g_dev_ssd1309_128x64_f_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
     if (page_did_change) {
       uint8_t end = WIDTH - 1;
       while (end > start && full_buffer[page][end] == buf[end]) end--;
-      column_end[page] = end + 1;
-      memcpy(full_buffer[page], buf, WIDTH);
+      end++;
+      column_end[page] = end;
+      memcpy(full_buffer[page] + start, buf + start, end - start);
     }
 
     const bool is_last_page = page == PAGE_COUNT - 1;

--- a/src/clib/u8g_dev_ssd1309_128x64.c
+++ b/src/clib/u8g_dev_ssd1309_128x64.c
@@ -147,7 +147,7 @@ uint8_t u8g_dev_ssd1309_128x64_f_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
     uint8_t page = pb->p.page;
     static uint8_t full_buffer[PAGE_COUNT][WIDTH] U8G_NOCOMMON;
     static uint8_t column_start[PAGE_COUNT] = {},
-                   column_width[PAGE_COUNT] = {};
+                   column_count[PAGE_COUNT] = {};
 
     uint8_t start = 0;
     while (start < WIDTH && full_buffer[page][start] == buf[start]) start++;
@@ -157,8 +157,8 @@ uint8_t u8g_dev_ssd1309_128x64_f_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
     if (page_changed) {
       uint8_t end = WIDTH - 1;
       while (end > start && full_buffer[page][end] == buf[end]) end--;
-      const uint8_t width = column_width[page] = end - start + 1;
-      memcpy(full_buffer[page] + start, buf + start, width);
+      const uint8_t count = column_count[page] = end - start + 1;
+      memcpy(full_buffer[page] + start, buf + start, count);
     }
 
     /* Only send buffer after the last page has been cached */
@@ -168,7 +168,7 @@ uint8_t u8g_dev_ssd1309_128x64_f_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
       static bool has_rendered = false;
       for (uint8_t page = 0; page < PAGE_COUNT; page++) {
         const uint8_t start = has_rendered ? column_start[page] : 0,
-                      width = has_rendered ? column_width[page] : WIDTH;
+                      count = has_rendered ? column_count[page] : WIDTH;
         const bool page_changed = start < WIDTH;
         if (page_changed) {
           u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd1309_128x64_data_start);
@@ -178,7 +178,7 @@ uint8_t u8g_dev_ssd1309_128x64_f_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
             u8g_WriteByte(u8g, dev, 0x10 | (start >> 4));     /* Start column high nybble */
           }
           u8g_SetAddress(u8g, dev, 1);                        /* Data mode */
-          u8g_WriteSequence(u8g, dev, width, full_buffer[page] + start);
+          u8g_WriteSequence(u8g, dev, count, full_buffer[page] + start);
         }
       }
       u8g_SetChipSelect(u8g, dev, 0);


### PR DESCRIPTION
This draft PR is a working proof of concept that improves screen refresh rate.
The impact is most relevant when combined with the recent PR that adds SW I2C support [#26433](https://github.com/MarlinFirmware/Marlin/pull/26433) to Marlin.

# Working principle

* Accumulates all pages in a new buffer (~~8kB~~ **1kB** of RAM)
* Sends all at once once the last page is received.
* Keeps track of which didn't change and skips them

## ~~This is a hack~~

~~This is a draft proof of concept because the correct way would be to handle the full buffer directly:~~
* ~~Increasing the PAGE_HEIGHT~~
* ~~Figuring out the data layout inside the u8glib buffer~~
* ~~Finding how to setup the screen to take the buffer in the same layout~~

**Update:** Not a hack in the end, this is also the way u8glib handles double page buffers in e.g SSD1306

# Video comparisons

Make sure to enable sound, the audio feedback I added on each line change makes the difference easier to appreciate.

## Original 

* SW I2C with an SSD1309 display 

https://github.com/MarlinFirmware/U8glib-HAL/assets/777196/cc458db1-6388-437a-a969-d9dd0f5a7a87

## This PR:

* Same but with the full buffer and sending only changed pages

https://github.com/MarlinFirmware/U8glib-HAL/assets/777196/77cbb03d-9ecd-45d6-bcaf-ca74fb5b08b1

----
----

# Addendum

* Extra tweaks for max performance

## Max clock speed
* Original SW I2C but passing 1_000_000 as clock speed
* SoftWire still adds `delayMicroseconds(1)`
* Measured 138kHz clock

https://github.com/MarlinFirmware/U8glib-HAL/assets/777196/f47a1dd0-f25f-4ded-924c-5000a31b5f95

## No delays
* Original but removing **all `delayMicroseconds` calls completely** from the SoftWire library
* 205kHz

https://github.com/MarlinFirmware/U8glib-HAL/assets/777196/ff73f1a4-739e-40fd-9173-bbd1c5ee7ea4

## ALL TOGETHER
* Full buffer sending only changed pages
* Removed all `delayMicroseconds` calls
* Use FASTIO instead of `digitalWrite`
* Use platform specific port direction setup (instead of Arduino's `pinMode`)
* Measured ~~240kHz~~ clock speed **Update: now 260kHz** 

https://github.com/MarlinFirmware/U8glib-HAL/assets/777196/ccca0e6b-78d8-4409-a0bf-af40c5d41bfd

---

## Test setup

* Ultimaker 2
* SKR3 board
* Running a custom branch that includes these two open PRs: [26441](https://github.com/MarlinFirmware/Marlin/pull/26441), [26433](https://github.com/MarlinFirmware/Marlin/pull/26433) and some non-relevant tweaks like adding sound on menu item changes.