### PR TITLE
Add MFL GD32 support

### DIFF
--- a/src/clib/u8g.h
+++ b/src/clib/u8g.h
@@ -684,6 +684,10 @@ uint8_t u8g_com_esp32_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
 uint8_t u8g_com_samd51_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);                /* u8g_com_samd51_hw_spi.cpp */
 uint8_t u8g_com_samd51_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);         /* u8g_com_samd51_st7920_hw_spi.cpp */
 
+uint8_t u8g_com_mfl_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);     /* u8g_com_mfl_hw_spi.cpp */
+uint8_t u8g_com_mfl_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);    /* u8g_com_mfl_ssd_i2c.cpp */
+
+
 /*
   Translation of system specific com drives to generic com names
   At the moment, the following generic com drives are available
@@ -758,6 +762,13 @@ defined(__18CXX) || defined(__PIC32MX)
 #ifdef __SAMD51__
 #define U8G_COM_HW_SPI u8g_com_samd51_hw_spi_fn
 #define U8G_COM_ST7920_HW_SPI u8g_com_samd51_st7920_hw_spi_fn
+#endif
+#endif
+
+#ifndef U8G_COM_HW_SPI
+#ifdef ARDUINO_ARCH_MFL
+#define U8G_COM_HW_SPI u8g_com_mfl_hw_spi_fn
+#define U8G_COM_ST7920_HW_SPI u8g_com_null_fn
 #endif
 #endif
 
@@ -860,6 +871,12 @@ defined(__18CXX) || defined(__PIC32MX)
 #ifndef U8G_COM_SSD_I2C
 #ifdef ARDUINO_ARCH_ESP32
 #define U8G_COM_SSD_I2C u8g_com_esp32_ssd_i2c_fn
+#endif
+#endif
+
+#ifndef U8G_COM_SSD_I2C
+#ifdef ARDUINO_ARCH_MFL
+#define U8G_COM_SSD_I2C u8g_com_mfl_ssd_i2c_fn
 #endif
 #endif
 

--- a/src/clib/u8g_com_arduino_common.c
+++ b/src/clib/u8g_com_arduino_common.c
@@ -37,7 +37,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     #include <WProgram.h>
@@ -64,4 +64,4 @@
     }
   }
 
-#endif // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#endif // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)

--- a/src/clib/u8g_com_arduino_fast_parallel.c
+++ b/src/clib/u8g_com_arduino_fast_parallel.c
@@ -46,7 +46,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     // #include <WProgram.h>
@@ -221,7 +221,7 @@
     return 1;
   }
 
-#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   uint8_t u8g_com_arduino_fast_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
     return 1;

--- a/src/clib/u8g_com_arduino_no_en_parallel.c
+++ b/src/clib/u8g_com_arduino_no_en_parallel.c
@@ -59,7 +59,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     // #include <WProgram.h>
@@ -202,7 +202,7 @@
     return 1;
   }
 
-#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   uint8_t u8g_com_arduino_no_en_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
     return 1;

--- a/src/clib/u8g_com_arduino_parallel.c
+++ b/src/clib/u8g_com_arduino_parallel.c
@@ -53,7 +53,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     #include <WProgram.h>
@@ -152,7 +152,7 @@
     return 1;
   }
 
-#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   uint8_t u8g_com_arduino_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
     return 1;

--- a/src/clib/u8g_com_arduino_port_d_wr.c
+++ b/src/clib/u8g_com_arduino_port_d_wr.c
@@ -50,7 +50,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && defined(PORTD) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && defined(PORTD) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     #include <WProgram.h>
@@ -143,7 +143,7 @@
     return 1;
   }
 
-#else // if defined(ARDUINO) && defined(PORTD) && !defined(ARDUINO_ARCH_STM32)
+#else // if defined(ARDUINO) && defined(PORTD) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   uint8_t u8g_com_arduino_port_d_wr_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
     return 1;

--- a/src/clib/u8g_com_arduino_st7920_custom.c
+++ b/src/clib/u8g_com_arduino_st7920_custom.c
@@ -46,7 +46,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_st7920_hw_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_hw_spi.c
@@ -37,7 +37,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_st7920_spi.c
+++ b/src/clib/u8g_com_arduino_st7920_spi.c
@@ -43,7 +43,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_std_sw_spi.c
+++ b/src/clib/u8g_com_arduino_std_sw_spi.c
@@ -35,7 +35,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_sw_spi.c
+++ b/src/clib/u8g_com_arduino_sw_spi.c
@@ -41,7 +41,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     #include <WProgram.h>

--- a/src/clib/u8g_com_arduino_t6963.c
+++ b/src/clib/u8g_com_arduino_t6963.c
@@ -59,7 +59,7 @@
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   #if ARDUINO < 100
     // #include <WProgram.h>
@@ -337,7 +337,7 @@
     return 1;
   }
 
-#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   uint8_t u8g_com_arduino_t6963_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
     return 1;

--- a/src/clib/u8g_com_io.cpp
+++ b/src/clib/u8g_com_io.cpp
@@ -318,6 +318,26 @@
     return digitalRead(internal_pin_number);
   }
 
+#elif defined(ARDUINO_ARCH_MFL)
+
+  #include <Arduino.h>
+
+  void u8g_SetPinOutput(uint8_t internal_pin_number) {
+    pinMode(static_cast<pin_size_t>(internal_pin_number), OUTPUT);
+  }
+
+  void u8g_SetPinInput(uint8_t internal_pin_number) {
+    pinMode(static_cast<pin_size_t>(internal_pin_number), INPUT);
+  }
+
+  void u8g_SetPinLevel(uint8_t internal_pin_number, uint8_t level) {
+    digitalWrite(static_cast<pin_size_t>(internal_pin_number), level);
+  }
+
+  uint8_t u8g_GetPinLevel(uint8_t internal_pin_number) {
+    return digitalRead(static_cast<pin_size_t>(internal_pin_number));
+  }
+
 #elif defined(U8G_HAL_LINKS)
 
   #include <LCD_pin_routines.h>

--- a/src/clib/u8g_com_mfl_hw_spi.cpp
+++ b/src/clib/u8g_com_mfl_hw_spi.cpp
@@ -1,0 +1,62 @@
+/*
+  u8g_com_mfl_hw_spi.cpp
+
+  communication interface for SPI protocol
+*/
+
+#ifdef ARDUINO_ARCH_MFL
+
+#include "u8g.h"
+#include <SPI.h>
+
+static SPISettings spiConfig;
+static uint8_t msgInitCount = 2; // Ignore all messages until 2nd U8G_COM_MSG_INIT
+
+uint8_t u8g_com_mfl_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
+  if (msgInitCount) {
+    if (msg == U8G_COM_MSG_INIT) msgInitCount --;
+    if (msgInitCount) return -1;
+  }
+
+  switch(msg) {
+    case U8G_COM_MSG_STOP:
+      break;
+    case U8G_COM_MSG_INIT:
+      u8g_SetPIOutput(u8g, U8G_PI_CS);
+      u8g_SetPIOutput(u8g, U8G_PI_A0);
+      u8g_SetPIOutput(u8g, U8G_PI_RESET);
+
+      u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+
+      spiConfig = SPISettings(2500000, MSBFIRST, SPI_MODE0); // 2.5 Mbits base clock
+      SPI.begin();
+      break;
+
+    case U8G_COM_MSG_ADDRESS:           /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+      u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+      break;
+
+    case U8G_COM_MSG_CHIP_SELECT:       /* arg_val == 0 means HIGH level of U8G_PI_CS */
+      u8g_SetPILevel(u8g, U8G_PI_CS, arg_val ? LOW : HIGH); /* CS = 0 (low active) */
+      break;
+
+    case U8G_COM_MSG_RESET:
+      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+      break;
+
+    case U8G_COM_MSG_WRITE_BYTE:
+      SPI.beginTransaction(spiConfig);
+      SPI.transfer(arg_val);
+      SPI.endTransaction();
+      break;
+
+    case U8G_COM_MSG_WRITE_SEQ:
+      SPI.beginTransaction(spiConfig);
+      SPI.transfer((uint8_t *)arg_ptr, arg_val);
+      SPI.endTransaction();
+      break;
+  }
+  return 1;
+}
+
+#endif // ARDUINO_ARCH_MFL

--- a/src/clib/u8g_com_mfl_hw_spi.cpp
+++ b/src/clib/u8g_com_mfl_hw_spi.cpp
@@ -10,11 +10,11 @@
 #include <SPI.h>
 
 static SPISettings spiConfig;
-static uint8_t msgInitCount = 2; // Ignore all messages until 2nd U8G_COM_MSG_INIT
+static uint8_t msgInitCount = 2;  // Ignore all messages until 2nd U8G_COM_MSG_INIT
 
 uint8_t u8g_com_mfl_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
   if (msgInitCount) {
-    if (msg == U8G_COM_MSG_INIT) msgInitCount --;
+    if (msg == U8G_COM_MSG_INIT) msgInitCount--;
     if (msgInitCount) return -1;
   }
 
@@ -25,31 +25,24 @@ uint8_t u8g_com_mfl_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *ar
       u8g_SetPIOutput(u8g, U8G_PI_CS);
       u8g_SetPIOutput(u8g, U8G_PI_A0);
       u8g_SetPIOutput(u8g, U8G_PI_RESET);
-
       u8g_SetPILevel(u8g, U8G_PI_CS, 1);
-
-      spiConfig = SPISettings(2500000, MSBFIRST, SPI_MODE0); // 2.5 Mbits base clock
+      spiConfig = SPISettings(2500000, MSBFIRST, SPI_MODE0);  // 2.5 Mbits base clock
       SPI.begin();
       break;
-
-    case U8G_COM_MSG_ADDRESS:           /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+    case U8G_COM_MSG_ADDRESS:                                 // define cmd (arg_val = 0) or data mode (arg_val = 1)
       u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
       break;
-
-    case U8G_COM_MSG_CHIP_SELECT:       /* arg_val == 0 means HIGH level of U8G_PI_CS */
-      u8g_SetPILevel(u8g, U8G_PI_CS, arg_val ? LOW : HIGH); /* CS = 0 (low active) */
+    case U8G_COM_MSG_CHIP_SELECT:                             // arg_val == 0 means HIGH level of U8G_PI_CS
+      u8g_SetPILevel(u8g, U8G_PI_CS, arg_val ? LOW : HIGH);   // CS = 0 (low active)
       break;
-
     case U8G_COM_MSG_RESET:
       u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
       break;
-
     case U8G_COM_MSG_WRITE_BYTE:
       SPI.beginTransaction(spiConfig);
       SPI.transfer(arg_val);
       SPI.endTransaction();
       break;
-
     case U8G_COM_MSG_WRITE_SEQ:
       SPI.beginTransaction(spiConfig);
       SPI.transfer((uint8_t *)arg_ptr, arg_val);
@@ -59,4 +52,4 @@ uint8_t u8g_com_mfl_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *ar
   return 1;
 }
 
-#endif // ARDUINO_ARCH_MFL
+#endif  // ARDUINO_ARCH_MFL

--- a/src/clib/u8g_com_mfl_ssd_i2c.cpp
+++ b/src/clib/u8g_com_mfl_ssd_i2c.cpp
@@ -10,45 +10,39 @@
 #include <Wire.h>
 
 /*
-  BUFFER_LENGTH is defined in libraries\Wire\utility\WireBase.h
+  WIRE_BUFFER_LENGTH is defined in arduino framework libraries\Wire\src\Wire.h
   Default value is 32
   Increate this value to 144 to send U8G_COM_MSG_WRITE_SEQ in single block
 */
 
-#if defined(BUFFER_LENGTH) && BUFFER_LENGTH < 144
-#define I2C_MAX_LENGTH (BUFFER_LENGTH - 1)
-#endif // BUFFER_LENGTH
+#if defined(WIRE_BUFFER_LENGTH) && WIRE_BUFFER_LENGTH < 144
+  #define I2C_MAX_LENGTH (WIRE_BUFFER_LENGTH - 1)
+#endif  // WIRE_BUFFER_LENGTH
 
 static uint8_t control;
-static uint8_t msgInitCount = 2; // Ignore all messages until 2nd U8G_COM_MSG_INIT
+static uint8_t msgInitCount = 2;      // Ignore all messages until 2nd U8G_COM_MSG_INIT
 
-uint8_t u8g_com_mfl_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
-{
+uint8_t u8g_com_mfl_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
   if (msgInitCount) {
     if (msg == U8G_COM_MSG_INIT) msgInitCount--;
     if (msgInitCount) return -1;
   }
 
-  switch (msg)
-  {
+  switch (msg) {
     case U8G_COM_MSG_INIT:
       Wire.setClock(400000);
       Wire.begin();
       break;
-
-    case U8G_COM_MSG_ADDRESS:           /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+    case U8G_COM_MSG_ADDRESS:           // Define cmd (arg_val = 0) or data mode (arg_val = 1)
       control = arg_val ? 0x40 : 0x00;
       break;
-
     case U8G_COM_MSG_WRITE_BYTE:
       Wire.beginTransmission(0x3c);
       Wire.write(control);
       Wire.write(arg_val);
       Wire.endTransmission();
       break;
-
-    case U8G_COM_MSG_WRITE_SEQ:
-    {
+    case U8G_COM_MSG_WRITE_SEQ: {
       uint8_t* dataptr = (uint8_t*)arg_ptr;
       #ifdef I2C_MAX_LENGTH
         while (arg_val > 0) {
@@ -70,7 +64,7 @@ uint8_t u8g_com_mfl_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *a
         Wire.write(control);
         Wire.write(dataptr, arg_val);
         Wire.endTransmission();
-      #endif // I2C_MAX_LENGTH
+      #endif  // I2C_MAX_LENGTH
       break;
     }
 
@@ -78,4 +72,4 @@ uint8_t u8g_com_mfl_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *a
   return 1;
 }
 
-#endif // ARDUINO_ARCH_MFL
+#endif  // ARDUINO_ARCH_MFL

--- a/src/clib/u8g_com_mfl_ssd_i2c.cpp
+++ b/src/clib/u8g_com_mfl_ssd_i2c.cpp
@@ -1,0 +1,81 @@
+/*
+  u8g_com_mfl_ssd_i2c.cpp
+
+  communication interface for SSDxxxx chip variant I2C protocol
+*/
+
+#ifdef ARDUINO_ARCH_MFL
+
+#include "u8g.h"
+#include <Wire.h>
+
+/*
+  BUFFER_LENGTH is defined in libraries\Wire\utility\WireBase.h
+  Default value is 32
+  Increate this value to 144 to send U8G_COM_MSG_WRITE_SEQ in single block
+*/
+
+#if defined(BUFFER_LENGTH) && BUFFER_LENGTH < 144
+#define I2C_MAX_LENGTH (BUFFER_LENGTH - 1)
+#endif // BUFFER_LENGTH
+
+static uint8_t control;
+static uint8_t msgInitCount = 2; // Ignore all messages until 2nd U8G_COM_MSG_INIT
+
+uint8_t u8g_com_mfl_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+{
+  if (msgInitCount) {
+    if (msg == U8G_COM_MSG_INIT) msgInitCount--;
+    if (msgInitCount) return -1;
+  }
+
+  switch (msg)
+  {
+    case U8G_COM_MSG_INIT:
+      Wire.setClock(400000);
+      Wire.begin();
+      break;
+
+    case U8G_COM_MSG_ADDRESS:           /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+      control = arg_val ? 0x40 : 0x00;
+      break;
+
+    case U8G_COM_MSG_WRITE_BYTE:
+      Wire.beginTransmission(0x3c);
+      Wire.write(control);
+      Wire.write(arg_val);
+      Wire.endTransmission();
+      break;
+
+    case U8G_COM_MSG_WRITE_SEQ:
+    {
+      uint8_t* dataptr = (uint8_t*)arg_ptr;
+      #ifdef I2C_MAX_LENGTH
+        while (arg_val > 0) {
+          Wire.beginTransmission(0x3c);
+          Wire.write(control);
+          if (arg_val <= I2C_MAX_LENGTH) {
+            Wire.write(dataptr, arg_val);
+            arg_val = 0;
+          }
+          else {
+            Wire.write(dataptr, I2C_MAX_LENGTH);
+            arg_val -= I2C_MAX_LENGTH;
+            dataptr += I2C_MAX_LENGTH;
+          }
+          Wire.endTransmission();
+        }
+      #else
+        Wire.beginTransmission(0x3c);
+        Wire.write(control);
+        Wire.write(dataptr, arg_val);
+        Wire.endTransmission();
+      #endif // I2C_MAX_LENGTH
+      break;
+    }
+
+  }
+  return 1;
+}
+
+#endif // ARDUINO_ARCH_MFL

--- a/src/clib/u8g_dev_ht1632.c
+++ b/src/clib/u8g_dev_ht1632.c
@@ -60,7 +60,7 @@ Usage:
 
 #include "u8g.h"
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
   #if ARDUINO < 100
     #include <WProgram.h>
   #else
@@ -99,7 +99,7 @@ Usage:
 #define HT1632_DATA_LEN         8               // Data are 4*2 bits
 #define HT1632_ADDR_LEN         7               // Address are 7 bits
 
-#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   // #define WR_PIN 3
   // #define DATA_PIN 2
@@ -217,7 +217,7 @@ Usage:
     digitalWrite(cs_pin, HIGH);
   }
 
-#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32)
+#else // if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_MFL)
 
   void ht1632_init(u8g_t *u8g) {
   }


### PR DESCRIPTION
This provides the required changes to allow GD32 (GD32F303RET6) to build U8glib-HAL for Marlin Firmware.
This was modeled similarly to how STM32 is handled. Since the MFL Arduino core uses the #define ARDUINO, we need to also provide our own compilation defines.

We currently use ARDUINO_ARCH_MFL for this purpose, but this can be changed for clarity, or any other reason, to suit Marlin Firmware.

These changes are a requirement before merging upstream Marlin support for this platform.